### PR TITLE
Bump playing card dependency to v2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,6 @@ let package = Package(
     name: "DeckOfPlayingCards",
     dependencies: [
         .Package(url: "https://github.com/apple/example-package-fisheryates.git", majorVersion: 1),
-        .Package(url: "https://github.com/apple/example-package-playingcard.git", majorVersion: 1),
+        .Package(url: "https://github.com/apple/example-package-playingcard.git", majorVersion: 2),
     ]
 )


### PR DESCRIPTION
The tag should be included in the master branch. The current master branch cannot build.
